### PR TITLE
HOTT-2786: API docs resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ workflows:
           name: apply_staging
           environment: staging
           context: trade-tariff-bot-aws-staging
-          requires: [apply_development]
+          requires: [smoketest_development]
           filters:
             branches:
               only:
@@ -165,7 +165,7 @@ workflows:
 
       - hold_apply_production:
           type: approval
-          requires: [apply_staging]
+          requires: [smoketest_staging]
           filters:
             branches:
               only:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ contexts are used for each environment.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/acm | aws/cloudfront-v1.0.1 |
+| <a name="module_api_docs_cloudfront"></a> [api\_docs\_cloudfront](#module\_api\_docs\_cloudfront) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.0.1 |
 | <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.0.1 |
 | <a name="module_opensearch"></a> [opensearch](#module\_opensearch) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/opensearch | aws/opensearch-v1.0.0 |
 | <a name="module_ssm"></a> [ssm](#module\_ssm) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ssm | aws/ssm-v1.0.0 |
@@ -73,6 +74,7 @@ contexts are used for each environment.
 | Name | Type |
 |------|------|
 | [aws_cloudfront_cache_policy.cache_all_qsa](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/resources/cloudfront_cache_policy) | resource |
+| [aws_cloudfront_origin_access_identity.this](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/resources/cloudfront_origin_access_identity) | resource |
 | [aws_cloudfront_origin_request_policy.forward_all_qsa](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_iam_access_key.service_account](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/resources/iam_access_key) | resource |
 | [aws_iam_policy.this](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/resources/iam_policy) | resource |
@@ -80,8 +82,10 @@ contexts are used for each environment.
 | [aws_iam_user_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_acl.this](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_policy.api_docs](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_cloudfront_cache_policy.caching_disabled](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/data-sources/cloudfront_cache_policy) | data source |
+| [aws_iam_policy_document.api_docs_s3_policy](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_route53_zone.selected](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/data-sources/route53_zone) | data source |
 
 ## Inputs

--- a/acm.tf
+++ b/acm.tf
@@ -3,7 +3,7 @@ module "acm" {
   # Using the CF release, since that uses ACM as well :)
   # TODO: make a release of the ACM module. Maybe tidy it up too.
 
-  domain_name               = local.cdn_aliases[0]
-  subject_alternative_names = slice(local.cdn_aliases, 1, length(local.cdn_aliases))
+  domain_name               = local.cdn_alias
+  subject_alternative_names = [local.api_alias]
   route53_zone_id           = data.aws_route53_zone.selected.id
 }

--- a/cloudfront-api-docs.tf
+++ b/cloudfront-api-docs.tf
@@ -1,0 +1,50 @@
+resource "aws_cloudfront_origin_access_identity" "this" {
+  comment = "API Docs S3"
+}
+
+module "api_docs_cloudfront" {
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.0.1"
+
+  aliases         = [local.api_alias]
+  route53_zone_id = data.aws_route53_zone.selected.id
+  comment         = "API Docs ${title(var.environment)} CDN"
+
+  default_root_object = "index.html"
+  enabled             = true
+  is_ipv6_enabled     = true
+  price_class         = "PriceClass_100"
+
+  web_acl_id = module.waf.web_acl_id
+
+  logging_config = {
+    bucket = "trade-tariff-logs.s3.amazonaws.com"
+    prefix = "cloudfront/api-docs/${local.environment_key}"
+  }
+
+  origin = {
+    "api-docs-${var.environment}" = {
+      domain_name = aws_s3_bucket.this["api_docs"].bucket_regional_domain_name
+      origin_id   = aws_cloudfront_origin_access_identity.this.cloudfront_access_identity_path
+    }
+  }
+
+  cache_behavior = {
+    default = {
+      allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+      cached_methods         = ["GET", "HEAD"]
+      target_origin_id       = aws_cloudfront_origin_access_identity.this.cloudfront_access_identity_path
+      viewer_protocol_policy = "redirect-to-https"
+
+      cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+    }
+  }
+
+  viewer_certificate = {
+    ssl_support_method  = "sni-only"
+    acm_certificate_arn = module.acm.aws_acm_certificate_arn
+    depends_on = [
+      module.acm.aws_acm_certificate_arn
+    ]
+  }
+}

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -1,8 +1,3 @@
-data "aws_route53_zone" "selected" {
-  name         = local.base_url
-  private_zone = false
-}
-
 data "aws_cloudfront_cache_policy" "caching_disabled" {
   name = "Managed-CachingDisabled"
 }
@@ -10,7 +5,7 @@ data "aws_cloudfront_cache_policy" "caching_disabled" {
 module "cdn" {
   source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.0.1"
 
-  aliases         = local.cdn_aliases
+  aliases         = [local.cdn_alias]
   route53_zone_id = data.aws_route53_zone.selected.id
   comment         = "${title(var.environment)} CDN"
 

--- a/locals.tf
+++ b/locals.tf
@@ -5,10 +5,16 @@ locals {
   no_reply = "no-reply@${local.base_url}"
 
   environment_key = var.environment == "development" ? "dev" : var.environment
-  cdn_aliases     = var.environment == "production" ? ["www.${local.base_url}"] : ["${local.environment_key}.${local.base_url}"]
+  cdn_alias       = var.environment == "production" ? "www.${local.base_url}" : "${local.environment_key}.${local.base_url}"
+  api_alias       = var.environment == "production" ? "api.${local.base_url}" : "api.${local.environment_key}.${local.base_url}"
 
   tags = {
     Project     = local.project
     Environment = var.environment
   }
+}
+
+data "aws_route53_zone" "selected" {
+  name         = local.base_url
+  private_zone = false
 }

--- a/s3.tf
+++ b/s3.tf
@@ -3,6 +3,7 @@ locals {
     persistence          = "${local.project}-persistence-${var.environment}"
     opensearch_packages  = "${local.project}-opensearch-packages-${var.environment}"
     search_configuration = "${local.project}-search-configuration-${var.environment}"
+    api_docs             = "${local.project}-api-docs-${var.environment}"
   }
 }
 

--- a/s3.tf
+++ b/s3.tf
@@ -28,3 +28,20 @@ resource "aws_s3_bucket_public_access_block" "this" {
   block_public_policy     = true
   ignore_public_acls      = true
 }
+
+data "aws_iam_policy_document" "api_docs_s3_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.this["api_docs"].arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_cloudfront_origin_access_identity.this.iam_arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "api_docs" {
+  bucket = aws_s3_bucket.this["api_docs"].id
+  policy = data.aws_iam_policy_document.api_docs_s3_policy.json
+}


### PR DESCRIPTION
### Jira link

[HOTT-2786](https://transformuk.atlassian.net/browse/HOTT-2786)

### What?

I have added/removed/altered:

- Added an S3 bucket, including ACL, public access block, and bucket policy.
- Added a Cloudfront distribution for the API docs, including a Route 53 DNS record, and a SAN for the SSL certificate.

### Why?

I am doing this because:

- The API docs will be built out to static files and served from an S3 bucket.

### Additional information

This change introduces a staging environment for the API docs. The intended flow will be as follows:

- Non-`main` branches (possibly just PRs) will deploy over `development`.
- `main` branch will deploy to `staging`, and eventually `production` after manual approval.

The addresses for the API docs will become:

- Development: `api.dev.trade-tariff.service.gov.uk`
- Staging: `api.staging.trade-tariff.service.gov.uk`
- Production: `api.trade-tariff.service.gov.uk` (the same as it is now!) 
