### PR TITLE
FIX: API Docs CDN (Prod)

### DIFF
--- a/cloudfront-api-docs.tf
+++ b/cloudfront-api-docs.tf
@@ -16,7 +16,7 @@ resource "aws_cloudfront_distribution" "this" {
     }
   }
 
-  aliases             = var.environment == "production" ? [] : [local.api_alias]
+  aliases             = local.api_alias
   comment             = "API Docs ${title(var.environment)} CDN"
   default_root_object = "index.html"
   enabled             = true

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -102,9 +102,11 @@ resource "aws_cloudfront_origin_request_policy" "forward_all_qsa" {
   cookies_config {
     cookie_behavior = "all"
   }
+
   headers_config {
     header_behavior = "allViewer"
   }
+
   query_strings_config {
     query_string_behavior = "all"
   }


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Added the `alias` to the production API Docs CloudFront distribution, by removing the check for `production`.

### Why?

I am doing this because:

- At the time we migrated the API docs, the codebase was the same as it was on PaaS, so when we went to the production service all appeared to be working fine.  However, CloudFront was routing `api.trade-tariff.service.gov.uk` somewhere else. We could see this in the `via` header.

- As it turns out, there was a `cdn-route` service running in PaaS. Unbeknownst to us at the time we initially migrated, I couldn't use the `alias` input to this resource. Now I know why - there already was a CloudFront distribution linked to this domain - the PaaS-provisioned CDN.